### PR TITLE
feat: Allow customization of the number of stack lines

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,13 +7,14 @@
  * file that was distributed with this source code.
  */
 
+import type { SpecReporterOptions } from './src/Contracts'
 import { SpecReporter } from './src/Reporter'
 export { SpecReporter }
 
 /**
  * Spec reporter function
  */
-export function specReporter() {
-  const reporter = new SpecReporter()
+export function specReporter(options: Partial<SpecReporterOptions> = {}) {
+  const reporter = new SpecReporter(options)
   return reporter.open.bind(reporter)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
-        "@japa/errors-printer": "^1.3.6",
-        "@poppinss/cliui": "^3.0.1",
+        "@japa/errors-printer": "^1.3.8",
+        "@poppinss/cliui": "^3.0.2",
         "ms": "^2.1.3"
       },
       "devDependencies": {
@@ -252,6 +252,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@commitlint/config-validator": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.0.0.tgz",
@@ -454,13 +463,13 @@
       }
     },
     "node_modules/@japa/errors-printer": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@japa/errors-printer/-/errors-printer-1.3.6.tgz",
-      "integrity": "sha512-J5qD3eoyOJty6WXh2/mzGGrH/kxtJf5h3Lxe1AgrrrvBuYtKlpBlljr+NKt1oe9P07/7ecTPWnrHhOWPSsvr9A==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@japa/errors-printer/-/errors-printer-1.3.8.tgz",
+      "integrity": "sha512-iBS5vICZncqcFafEgmZie9/7hgsd727IGyzYWPSZSwRQFy4pCJTT1zzrVZL7pVDd0uUcOt2yUmkU8/hcWAd8WQ==",
       "dependencies": {
-        "@poppinss/cliui": "^3.0.1",
+        "@poppinss/cliui": "^3.0.2",
         "jest-diff": "^27.5.1",
-        "youch": "^3.1.1",
+        "youch": "^3.2.0",
         "youch-terminal": "^2.1.3"
       }
     },
@@ -585,11 +594,11 @@
       }
     },
     "node_modules/@poppinss/cliui": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-3.0.1.tgz",
-      "integrity": "sha512-L3kMPfwDJbbt5pE5zKdqrbVjphqMW90FINWJPkLfx6Fy3kVtO+2tmqqg2T+CRQia8KtsxHJS47mNeY6h6L0JMA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-3.0.2.tgz",
+      "integrity": "sha512-nrAosoQy0ex3wSw3VuigLs3XCsxDsnNvx4ZL4ZvdZlygrChMUKPKnlxctQk13IyUHaH4F/wvaHnfWg/inhA36w==",
       "dependencies": {
-        "@poppinss/colors": "^3.0.1",
+        "@poppinss/colors": "^3.0.2",
         "cli-boxes": "^3.0.0",
         "cli-table3": "^0.6.1",
         "color-support": "^1.1.3",
@@ -656,9 +665,9 @@
       }
     },
     "node_modules/@poppinss/colors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-3.0.1.tgz",
-      "integrity": "sha512-7nUk+v1iLVFjfjmyv4vTjzqucohuDw4PMhrcxTVHqt4uymweo5LIJwOQOmv0eUfRxgaSJJiUTpUaH0O0bMHLbQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-3.0.2.tgz",
+      "integrity": "sha512-kgIiDPKUV0IaNtzLKricxd3mMWepqCbgh2Mb0M8C5zyS1bJ0K86s6dMu9xEKtF2XksqyE0qV4ANtMnTCMjQgvA==",
       "dependencies": {
         "color-support": "^1.1.3",
         "kleur": "^4.1.4"
@@ -2124,9 +2133,9 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -2134,7 +2143,7 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "1.4.0"
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -2330,15 +2339,6 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "bin": {
         "color-support": "bin.js"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/columnify": {
@@ -2775,9 +2775,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11153,11 +11153,11 @@
       }
     },
     "node_modules/youch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.1.1.tgz",
-      "integrity": "sha512-H8DwI62kyzVAuumMiJTgOynPgKjuAWwns+LLjHhJKpnFP+n2yssC/XiDV0nuToIrm5WBsgmu8POmd7sFapFE8A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.2.0.tgz",
+      "integrity": "sha512-H+hTPaqFc1EDXHmp8sqOQe7pOvP3GlYovV+Dkg8sQ2RUy95p9gJeH2gJ64V4LYxh8wI8+4KqJjhbLt4DeUgzgQ==",
       "dependencies": {
-        "cookie": "^0.4.2",
+        "cookie": "^0.5.0",
         "mustache": "^4.2.0",
         "stacktracey": "^2.1.8"
       }
@@ -11388,6 +11388,12 @@
         }
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "optional": true
+    },
     "@commitlint/config-validator": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.0.0.tgz",
@@ -11556,13 +11562,13 @@
       }
     },
     "@japa/errors-printer": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@japa/errors-printer/-/errors-printer-1.3.6.tgz",
-      "integrity": "sha512-J5qD3eoyOJty6WXh2/mzGGrH/kxtJf5h3Lxe1AgrrrvBuYtKlpBlljr+NKt1oe9P07/7ecTPWnrHhOWPSsvr9A==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@japa/errors-printer/-/errors-printer-1.3.8.tgz",
+      "integrity": "sha512-iBS5vICZncqcFafEgmZie9/7hgsd727IGyzYWPSZSwRQFy4pCJTT1zzrVZL7pVDd0uUcOt2yUmkU8/hcWAd8WQ==",
       "requires": {
-        "@poppinss/cliui": "^3.0.1",
+        "@poppinss/cliui": "^3.0.2",
         "jest-diff": "^27.5.1",
-        "youch": "^3.1.1",
+        "youch": "^3.2.0",
         "youch-terminal": "^2.1.3"
       },
       "dependencies": {
@@ -11659,11 +11665,11 @@
       }
     },
     "@poppinss/cliui": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-3.0.1.tgz",
-      "integrity": "sha512-L3kMPfwDJbbt5pE5zKdqrbVjphqMW90FINWJPkLfx6Fy3kVtO+2tmqqg2T+CRQia8KtsxHJS47mNeY6h6L0JMA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-3.0.2.tgz",
+      "integrity": "sha512-nrAosoQy0ex3wSw3VuigLs3XCsxDsnNvx4ZL4ZvdZlygrChMUKPKnlxctQk13IyUHaH4F/wvaHnfWg/inhA36w==",
       "requires": {
-        "@poppinss/colors": "^3.0.1",
+        "@poppinss/colors": "^3.0.2",
         "cli-boxes": "^3.0.0",
         "cli-table3": "^0.6.1",
         "color-support": "^1.1.3",
@@ -11711,9 +11717,9 @@
       }
     },
     "@poppinss/colors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-3.0.1.tgz",
-      "integrity": "sha512-7nUk+v1iLVFjfjmyv4vTjzqucohuDw4PMhrcxTVHqt4uymweo5LIJwOQOmv0eUfRxgaSJJiUTpUaH0O0bMHLbQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-3.0.2.tgz",
+      "integrity": "sha512-kgIiDPKUV0IaNtzLKricxd3mMWepqCbgh2Mb0M8C5zyS1bJ0K86s6dMu9xEKtF2XksqyE0qV4ANtMnTCMjQgvA==",
       "requires": {
         "color-support": "^1.1.3",
         "kleur": "^4.1.4"
@@ -12824,11 +12830,11 @@
       "dev": true
     },
     "cli-table3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "requires": {
-        "colors": "1.4.0",
+        "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
       }
     },
@@ -12985,12 +12991,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "optional": true
     },
     "columnify": {
       "version": "1.6.0",
@@ -13339,9 +13339,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -19703,11 +19703,11 @@
       "dev": true
     },
     "youch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.1.1.tgz",
-      "integrity": "sha512-H8DwI62kyzVAuumMiJTgOynPgKjuAWwns+LLjHhJKpnFP+n2yssC/XiDV0nuToIrm5WBsgmu8POmd7sFapFE8A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.2.0.tgz",
+      "integrity": "sha512-H+hTPaqFc1EDXHmp8sqOQe7pOvP3GlYovV+Dkg8sQ2RUy95p9gJeH2gJ64V4LYxh8wI8+4KqJjhbLt4DeUgzgQ==",
       "requires": {
-        "cookie": "^0.4.2",
+        "cookie": "^0.5.0",
         "mustache": "^4.2.0",
         "stacktracey": "^2.1.8"
       }

--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "anyBranch": false
   },
   "dependencies": {
-    "@japa/errors-printer": "^1.3.6",
-    "@poppinss/cliui": "^3.0.1",
+    "@japa/errors-printer": "^1.3.8",
+    "@poppinss/cliui": "^3.0.2",
     "ms": "^2.1.3"
   },
   "publishConfig": {

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Shape of the SpecReporter possible options
+ */
+export interface SpecReporterOptions {
+  stackLinesCount: number
+}

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -2,5 +2,5 @@
  * Shape of the SpecReporter possible options
  */
 export interface SpecReporterOptions {
-  stackLinesCount: number
+  stackLinesCount?: number
 }

--- a/src/Reporter/index.ts
+++ b/src/Reporter/index.ts
@@ -11,18 +11,26 @@ import ms from 'ms'
 import { relative } from 'path'
 import { icons, logger } from '@poppinss/cliui'
 import { ErrorsPrinter } from '@japa/errors-printer'
+import type { SpecReporterOptions } from '../Contracts'
 import type { Emitter, Runner, GroupStartNode, TestEndNode } from '@japa/core'
 
 /**
  * Pretty prints the tests on the console
  */
 export class SpecReporter {
+  private options: SpecReporterOptions
   private currentSuiteName?: string
   private currentFileName?: string
   private currentGroupTitle?: string
   private currentTestTitle?: string
   private groupPayload?: GroupStartNode
   private uncaughtExceptions: { phase: 'test'; error: Error }[] = []
+
+  constructor(options: Partial<SpecReporterOptions> = {}) {
+    this.options = {
+      stackLinesCount: options.stackLinesCount || 5,
+    }
+  }
 
   /**
    * Returns the icon for the test
@@ -192,7 +200,9 @@ export class SpecReporter {
       console.log('')
     }
 
-    const errorPrinter = new ErrorsPrinter()
+    const errorPrinter = new ErrorsPrinter({
+      stackLinesCount: this.options.stackLinesCount,
+    })
 
     /**
      * Printing the errors tree


### PR DESCRIPTION
## Proposed changes

Allow customization of the number of lines in the trace stack for the spec reporter to be used as follows : 

```ts
 reporters: [specReporter({ stackLinesCount: 2 })],
```

**This PR depends on this one: https://github.com/japa/errors-printer/pull/2**

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
